### PR TITLE
Fix for process not started

### DIFF
--- a/DockerComposeFixture.Tests/DockerComposeFixture.Tests.csproj
+++ b/DockerComposeFixture.Tests/DockerComposeFixture.Tests.csproj
@@ -9,13 +9,19 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\DockerComposeFixture\DockerComposeFixture.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/DockerComposeFixture.Tests/DockerFixtureTests.cs
+++ b/DockerComposeFixture.Tests/DockerFixtureTests.cs
@@ -200,11 +200,11 @@ namespace DockerComposeFixture.Tests
             
             Assert.Throws<ArgumentException>(() =>
                 new DockerFixture().Init(
-                    () => new DockerFixtureOptions { DockerComposeFiles = new[] { "a" }, StartupTimeoutSecs = 0 },
+                    () => new DockerFixtureOptions { DockerComposeFiles = new[] { "docker-compose.yml" }, StartupTimeoutSecs = 0 },
                     compose.Object));
             Assert.Throws<ArgumentException>(() =>
                 new DockerFixture().Init(
-                    () => new DockerFixtureOptions { DockerComposeFiles = new[] { "a" }, StartupTimeoutSecs = -1 },
+                    () => new DockerFixtureOptions { DockerComposeFiles = new[] { "docker-compose.yml" }, StartupTimeoutSecs = -1 },
                     compose.Object));
         }
 

--- a/DockerComposeFixture.Tests/DockerFixtureTests.cs
+++ b/DockerComposeFixture.Tests/DockerFixtureTests.cs
@@ -27,7 +27,7 @@ namespace DockerComposeFixture.Tests
                 .Returns(new[] { "--------", " Up ", " Up " });
             compose.Setup(c => c.Up()).Returns(Task.Delay(ComposeUpRunDurationMs));
 
-            new DockerFixture()
+            new DockerFixture(null)
                 .Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object);
             compose.Verify(c => c.Init(It.IsAny<string>(), "up", "down"), Times.Once);
             compose.Verify(c => c.Down(), Times.Once);
@@ -45,7 +45,7 @@ namespace DockerComposeFixture.Tests
             compose.Setup(c => c.Up()).Returns(Task.Delay(ComposeUpRunDurationMs));
 
             var tmp = Path.GetTempFileName();
-            new DockerFixture()
+            new DockerFixture(null)
                 .Init(new[] { tmp }, "up", "down", 120, null, compose.Object);
             compose.Verify(c => c.Init($"-f \"{tmp}\"", "up", "down"), Times.Once);
             compose.Verify(c => c.Up(), Times.Once);
@@ -62,7 +62,7 @@ namespace DockerComposeFixture.Tests
                 .Returns(new[] { "--------", " Up ", " Up " });
 
             var tmp = Path.GetTempFileName();
-            var fixture = new DockerFixture();
+            var fixture = new DockerFixture(null);
 
             fixture.InitOnce(() => new DockerFixtureOptions { DockerComposeFiles = new[] { tmp } }, compose.Object);
             fixture.InitOnce(() => new DockerFixtureOptions { DockerComposeFiles = new[] { tmp } }, compose.Object);
@@ -80,12 +80,12 @@ namespace DockerComposeFixture.Tests
                 .Returns(new[] { "--------", " Up ", " Up " });
             const string successText = "Everything is up";
 
-            var logger = new Logger(null);
+            var logger = new ListLogger();
             var task = new Task(() =>
-                 new DockerFixture()
+                 new DockerFixture(null)
                     .Init(new[] { Path.GetTempFileName() }, "up", "down", 120,
                         outputLinesFromUp => outputLinesFromUp.Contains(successText),
-                        compose.Object, logger));
+                        compose.Object, new []{ logger}));
             task.Start();
             Thread.Sleep(100);
             logger.OnNext("foo");
@@ -104,13 +104,13 @@ namespace DockerComposeFixture.Tests
             compose.Setup(c => c.Ps())
                 .Returns(new[] { "--------", " Up ", " Up " });
             const string successText = "Everything is up";
-            var logger = new Logger(null);
-            compose.SetupGet(c => c.Logger).Returns(logger);
+            var logger = new ListLogger();
+            compose.SetupGet(c => c.Logger).Returns(new []{ logger});
 
             Assert.Throws<AggregateException>(() =>
             {
                 var task = new Task(() =>
-                    new DockerFixture()
+                    new DockerFixture(null)
                         .Init(new[] { Path.GetTempFileName() }, "up", "down", 120,
                             outputLinesFromUp => outputLinesFromUp.Contains(successText),
                             compose.Object));
@@ -150,7 +150,7 @@ namespace DockerComposeFixture.Tests
                 };
             });
 
-            new DockerFixture().Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object);
+            new DockerFixture(null).Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object);
 
             compose.Verify(c => c.Up(), Times.Once);
             compose.Verify(c => c.Ps(), Times.AtLeast(5));
@@ -172,7 +172,7 @@ namespace DockerComposeFixture.Tests
                 });
 
             Assert.Throws<DockerComposeException>(() =>
-                new DockerFixture().Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object));
+                new DockerFixture(null).Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object));
         }
 
 
@@ -184,7 +184,7 @@ namespace DockerComposeFixture.Tests
             compose.Setup(c => c.Up()).Returns(Task.CompletedTask);
             
             Assert.Throws<DockerComposeException>(() =>
-                new DockerFixture().Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object));
+                new DockerFixture(null).Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object));
             compose.Verify(c => c.Ps(), Times.Once);
         }
 
@@ -198,7 +198,7 @@ namespace DockerComposeFixture.Tests
 
             string fileDoesntExist = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Assert.Throws<ArgumentException>(() =>
-                new DockerFixture().Init(new[] { fileDoesntExist }, "up", "down", 120, null, compose.Object));
+                new DockerFixture(null).Init(new[] { fileDoesntExist }, "up", "down", 120, null, compose.Object));
         }
 
         [Fact]
@@ -207,11 +207,11 @@ namespace DockerComposeFixture.Tests
             var compose = new Mock<IDockerCompose>();
 
             Assert.Throws<ArgumentException>(() =>
-                new DockerFixture().Init(
+                new DockerFixture(null).Init(
                     () => new DockerFixtureOptions { DockerComposeFiles = new string[0] },
                     compose.Object));
             Assert.Throws<ArgumentException>(() =>
-                new DockerFixture().Init(
+                new DockerFixture(null).Init(
                     () => new DockerFixtureOptions { DockerComposeFiles = null },
                     compose.Object));
         }
@@ -222,11 +222,11 @@ namespace DockerComposeFixture.Tests
             var compose = new Mock<IDockerCompose>();
             
             Assert.Throws<ArgumentException>(() =>
-                new DockerFixture().Init(
+                new DockerFixture(null).Init(
                     () => new DockerFixtureOptions { DockerComposeFiles = new[] { "docker-compose.yml" }, StartupTimeoutSecs = 0 },
                     compose.Object));
             Assert.Throws<ArgumentException>(() =>
-                new DockerFixture().Init(
+                new DockerFixture(null).Init(
                     () => new DockerFixtureOptions { DockerComposeFiles = new[] { "docker-compose.yml" }, StartupTimeoutSecs = -1 },
                     compose.Object));
         }
@@ -243,7 +243,7 @@ namespace DockerComposeFixture.Tests
                 .Returns(new[] { "--------" })
                 .Returns(new[] { "--------", " Up ", " Up " });
 
-            var fixture = new DockerFixture();
+            var fixture = new DockerFixture(null);
             fixture.Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object);
             fixture.Dispose();
 

--- a/DockerComposeFixture.Tests/xunit.runner.json
+++ b/DockerComposeFixture.Tests/xunit.runner.json
@@ -1,0 +1,1 @@
+{ "diagnosticMessages":  true }

--- a/DockerComposeFixture/Compose/DockerCompose.cs
+++ b/DockerComposeFixture/Compose/DockerCompose.cs
@@ -12,7 +12,7 @@ namespace DockerComposeFixture.Compose
 {
     public class DockerCompose : IDockerCompose
     {
-        public DockerCompose(ILogger logger)
+        public DockerCompose(ILogger[] logger)
         {
             this.Logger = logger;
         }
@@ -34,12 +34,15 @@ namespace DockerComposeFixture.Compose
         private void RunProcess(ProcessStartInfo processStartInfo)
         {
             var runner = new ProcessRunner(processStartInfo);
-            runner.Subscribe(this.Logger);
+            foreach (var logger in this.Logger)
+            {
+                runner.Subscribe(logger);
+            }
             runner.Execute();
         }
 
         public int PauseMs => 1000;
-        public ILogger Logger { get; }
+        public ILogger[] Logger { get; }
 
         public void Down()
         {
@@ -53,7 +56,10 @@ namespace DockerComposeFixture.Compose
             var runner = new ProcessRunner(ps);
             var observerToQueue = new ObserverToQueue<string>();
 
-            runner.Subscribe(this.Logger);
+            foreach (var logger in this.Logger)
+            {
+                runner.Subscribe(logger);
+            }
             runner.Subscribe(observerToQueue);
             runner.Execute();
             return observerToQueue.Queue.ToArray();

--- a/DockerComposeFixture/Compose/DockerCompose.cs
+++ b/DockerComposeFixture/Compose/DockerCompose.cs
@@ -25,10 +25,10 @@ namespace DockerComposeFixture.Compose
             this.dockerComposeDownArgs = dockerComposeDownArgs;
         }
 
-        public void Up()
+        public Task Up()
         {
             var start = new ProcessStartInfo("docker-compose", $"{this.dockerComposeArgs} up {this.dockerComposeUpArgs}");
-            Task.Run(() =>  this.RunProcess(start) );
+            return Task.Run(() =>  this.RunProcess(start) );
         }
 
         private void RunProcess(ProcessStartInfo processStartInfo)

--- a/DockerComposeFixture/Compose/IDockerCompose.cs
+++ b/DockerComposeFixture/Compose/IDockerCompose.cs
@@ -12,6 +12,6 @@ namespace DockerComposeFixture.Compose
         IEnumerable<string> Ps();
         Task Up();
         int PauseMs { get; }
-        ILogger Logger { get; }
+        ILogger[] Logger { get; }
     }
 }

--- a/DockerComposeFixture/Compose/IDockerCompose.cs
+++ b/DockerComposeFixture/Compose/IDockerCompose.cs
@@ -1,6 +1,7 @@
 ﻿using DockerComposeFixture.Logging;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace DockerComposeFixture.Compose
 {
@@ -9,7 +10,7 @@ namespace DockerComposeFixture.Compose
         void Init(string dockerComposeArgs, string dockerComposeUpArgs, string dockerComposeDownArgs);
         void Down();
         IEnumerable<string> Ps();
-        void Up();
+        Task Up();
         int PauseMs { get; }
         ILogger Logger { get; }
     }

--- a/DockerComposeFixture/DockerComposeFixture.csproj
+++ b/DockerComposeFixture/DockerComposeFixture.csproj
@@ -18,4 +18,8 @@ Made it not rebuild on every test run</PackageReleaseNotes>
     <AssemblyVersion>1.0.11.0</AssemblyVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.0" />
+  </ItemGroup>
+
 </Project>

--- a/DockerComposeFixture/DockerComposeFixture.csproj
+++ b/DockerComposeFixture/DockerComposeFixture.csproj
@@ -2,7 +2,20 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.9</Version>
+    <Version>1.0.11</Version>
+    <Authors>Joe Shearn</Authors>
+    <Product>Docker Compose Fixture</Product>
+    <Description>This xUnit fixture will start up a dockerised application and allow you to run integration tests against it.</Description>
+    <Company>Joe Shearn</Company>
+    <Copyright>Joe Shearn</Copyright>
+    <PackageProjectUrl>https://github.com/devjoes/DockerComposeFixture</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/devjoes/DockerComposeFixture/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/devjoes/DockerComposeFixture</RepositoryUrl>
+    <PackageTags>docker docker-compose xunit</PackageTags>
+    <PackageReleaseNotes>Added xUnit logging
+Handled scenario where docker-compose stops
+Made it not rebuild on every test run</PackageReleaseNotes>
+    <AssemblyVersion>1.0.11.0</AssemblyVersion>
   </PropertyGroup>
 
 </Project>

--- a/DockerComposeFixture/DockerFixture.cs
+++ b/DockerComposeFixture/DockerFixture.cs
@@ -181,10 +181,15 @@ namespace DockerComposeFixture
             }
 
             this.logger.Log("---- starting docker services ----");
-            this.dockerCompose.Up();
+            var upTask = this.dockerCompose.Up();
 
             for (int i = 0; i < this.startupTimeoutSecs; i++)
             {
+                if (upTask.IsCompleted)
+                {
+                    this.logger.Log("docker-compose exited prematurely");
+                    break;
+                }
                 this.logger.Log("---- checking docker services ----");
                 Thread.Sleep(this.dockerCompose.PauseMs);
                 if (this.customUpTest != null)

--- a/DockerComposeFixture/DockerFixture.cs
+++ b/DockerComposeFixture/DockerFixture.cs
@@ -182,17 +182,20 @@ namespace DockerComposeFixture
             {
                 this.logger.Log("---- checking docker services ----");
                 Thread.Sleep(this.dockerCompose.PauseMs);
-                var (hasContainers, containersAreUp) = this.CheckIfRunning();
-                if (hasContainers && containersAreUp)
+                if (this.customUpTest != null)
                 {
-                    this.logger.Log("---- docker services are up ----");
-                    if (this.customUpTest == null)
-                    {
-                        return;
-                    }
                     if (this.customUpTest(this.logger.ConsoleOutput))
                     {
                         this.logger.Log("---- custom up test satisfied ----");
+                        return;
+                    }
+                }
+                else
+                {
+                    var (hasContainers, containersAreUp) = this.CheckIfRunning();
+                    if (hasContainers && containersAreUp)
+                    {
+                        this.logger.Log("---- docker services are up ----");
                         return;
                     }
                 }

--- a/DockerComposeFixture/DockerFixtureOptions.cs
+++ b/DockerComposeFixture/DockerFixtureOptions.cs
@@ -13,11 +13,13 @@ namespace DockerComposeFixture
         /// Checks whether the docker-compose services have come up correctly based upon the output of docker-compose
         /// </summary>
         public Func<List<string>, bool> CustomUpTest { get; set; }
+
         /// <summary>
         /// Array of docker compose files
         /// Files are converted into the arguments '-f file1 -f file2 etc'
+        /// Default is 'docker-compose.yml'
         /// </summary>
-        public string[] DockerComposeFiles { get; set; }
+        public string[] DockerComposeFiles { get; set; } = new[] { "docker-compose.yml" };
         /// <summary>
         /// When true this logs docker-compose output to %temp%\docker-compose-*.log
         /// </summary>

--- a/DockerComposeFixture/DockerFixtureOptions.cs
+++ b/DockerComposeFixture/DockerFixtureOptions.cs
@@ -12,7 +12,7 @@ namespace DockerComposeFixture
         /// <summary>
         /// Checks whether the docker-compose services have come up correctly based upon the output of docker-compose
         /// </summary>
-        public Func<List<string>, bool> CustomUpTest { get; set; }
+        public Func<string[], bool> CustomUpTest { get; set; }
 
         /// <summary>
         /// Array of docker compose files

--- a/DockerComposeFixture/DockerFixtureOptions.cs
+++ b/DockerComposeFixture/DockerFixtureOptions.cs
@@ -24,14 +24,14 @@ namespace DockerComposeFixture
         public bool DebugLog { get; set; }
         /// <summary>
         /// Arguments to append after 'docker-compose -f file.yml up'
-        /// Default is 'docker-compose -f file.yml up --build'
+        /// Default is 'docker-compose -f file.yml up' you can append '--build' if you want it to always build
         /// </summary>
-        public string DockerComposeUpArgs { get; set; } = "--build";
+        public string DockerComposeUpArgs { get; set; } = "";
         /// <summary>
         /// Arguments to append after 'docker-compose -f file.yml down'
-        /// Default is 'docker-compose -f file.yml down --remove-orphans --rmi all'
+        /// Default is 'docker-compose -f file.yml down --remove-orphans' you can add '--rmi all' if you want to guarantee a fresh build on each test
         /// </summary>
-        public string DockerComposeDownArgs { get; set; } = "--remove-orphans --rmi all";
+        public string DockerComposeDownArgs { get; set; } = "--remove-orphans";
 
         public void Validate()
         {

--- a/DockerComposeFixture/DockerFixtureOptions.cs
+++ b/DockerComposeFixture/DockerFixtureOptions.cs
@@ -33,8 +33,17 @@ namespace DockerComposeFixture
         /// </summary>
         public string DockerComposeDownArgs { get; set; } = "--remove-orphans";
 
+        /// <summary>
+        /// How many seconds to wait for the application to start before giving up. (Default is 120.)
+        /// </summary>
+        public int StartupTimeoutSecs { get; set; } = 120;
+
         public void Validate()
         {
+            if (this.StartupTimeoutSecs < 1)
+            {
+                throw new ArgumentException(nameof(this.StartupTimeoutSecs));
+            }
             if (this.DockerComposeFiles == null
                 || this.DockerComposeFiles.Length == 0)
             {

--- a/DockerComposeFixture/Exceptions/DockerComposeException.cs
+++ b/DockerComposeFixture/Exceptions/DockerComposeException.cs
@@ -7,9 +7,9 @@ namespace DockerComposeFixture.Exceptions
 {
     public class DockerComposeException:Exception
     {
-        public DockerComposeException(ILogger logger):base($"docker-compose failed - see {nameof(DockerComposeOutput)} property")
+        public DockerComposeException(string[] loggedLines):base($"docker-compose failed - see {nameof(DockerComposeOutput)} property")
         {
-            this.DockerComposeOutput = logger.ConsoleOutput.ToArray();
+            this.DockerComposeOutput = loggedLines;
         }
 
         public string[] DockerComposeOutput { get; set; }

--- a/DockerComposeFixture/IDockerFixtureOptions.cs
+++ b/DockerComposeFixture/IDockerFixtureOptions.cs
@@ -5,7 +5,7 @@ namespace DockerComposeFixture
 {
     public interface IDockerFixtureOptions
     {
-        Func<List<string>, bool> CustomUpTest { get; set; }
+        Func<string[], bool> CustomUpTest { get; set; }
         string[] DockerComposeFiles { get; set; }
         bool DebugLog { get; set; }
         string DockerComposeUpArgs { get; set; }

--- a/DockerComposeFixture/IDockerFixtureOptions.cs
+++ b/DockerComposeFixture/IDockerFixtureOptions.cs
@@ -10,6 +10,7 @@ namespace DockerComposeFixture
         bool DebugLog { get; set; }
         string DockerComposeUpArgs { get; set; }
         string DockerComposeDownArgs { get; set; }
+        int StartupTimeoutSecs { get; set; }
 
         void Validate();
 

--- a/DockerComposeFixture/Logging/ConsoleLogger.cs
+++ b/DockerComposeFixture/Logging/ConsoleLogger.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace DockerComposeFixture.Logging
+{
+    public class ConsoleLogger : ILogger
+    {
+        public void OnCompleted()
+        {
+            
+        }
+
+        public void OnError(Exception error)
+        {
+            this.Log(error.Message + "\n" + error.StackTrace);
+            throw error;
+        }
+
+
+        public void OnNext(string value)
+        {
+            this.Log(value);
+        }
+
+        public void Log(string msg)
+        {
+            Debug.WriteLine(msg);
+            Console.WriteLine(msg);
+        }
+        
+    }
+}

--- a/DockerComposeFixture/Logging/FileLogger.cs
+++ b/DockerComposeFixture/Logging/FileLogger.cs
@@ -1,17 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
+using System.Text;
 
 namespace DockerComposeFixture.Logging
 {
-    public class Logger : ILogger
+    public class FileLogger : ILogger
     {
         private readonly string logfileName;
 
-        public Logger(string logfileName)
+        public FileLogger(string logfileName)
         {
-            this.ConsoleOutput = new List<string>();
             if (logfileName != null)
             {
                 if (File.Exists(logfileName))
@@ -23,10 +22,12 @@ namespace DockerComposeFixture.Logging
         }
         public void OnCompleted()
         {
+            
         }
 
         public void OnError(Exception error)
         {
+            this.Log(error.Message + "\n" + error.StackTrace);
             throw error;
         }
 
@@ -38,22 +39,14 @@ namespace DockerComposeFixture.Logging
 
         public void Log(string msg)
         {
-            Debug.WriteLine(msg);
-            Console.WriteLine(msg);
-            this.ConsoleOutput.Add(msg);
-            if (!string.IsNullOrEmpty(this.logfileName))
+            using (var stream = new FileStream(this.logfileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            using (var writer = new StreamWriter(stream))
             {
-                using (var stream = new FileStream(this.logfileName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
-                using (var writer = new StreamWriter(stream))
-                {
-                    writer.WriteLine(msg);
-                    writer.Flush();
-                    writer.Close();
-                }
+                writer.WriteLine(msg);
+                writer.Flush();
+                writer.Close();
             }
 
         }
-
-        public List<string> ConsoleOutput { get; }
     }
 }

--- a/DockerComposeFixture/Logging/ILogger.cs
+++ b/DockerComposeFixture/Logging/ILogger.cs
@@ -6,6 +6,5 @@ namespace DockerComposeFixture.Logging
     public interface ILogger : IObserver<string>
     {
         void Log(string msg);
-        List<string> ConsoleOutput { get; }
     }
 }

--- a/DockerComposeFixture/Logging/ListLogger.cs
+++ b/DockerComposeFixture/Logging/ListLogger.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DockerComposeFixture.Logging
+{
+    public class ListLogger : ILogger
+    {
+        public ListLogger()
+        {
+            this.LoggedLines = new List<string>();
+        }
+        public void OnCompleted()
+        {
+            
+        }
+
+        public void OnError(Exception error)
+        {
+            this.Log(error.Message + "\n" + error.StackTrace);
+            throw error;
+        }
+
+
+        public void OnNext(string value)
+        {
+            this.Log(value);
+        }
+
+        public void Log(string msg)
+        {
+            this.LoggedLines.Add(msg);
+        }
+
+        public List<string> LoggedLines { get; }
+    }
+}

--- a/DockerComposeFixture/Logging/LoggingExtensionMethods.cs
+++ b/DockerComposeFixture/Logging/LoggingExtensionMethods.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+
+namespace DockerComposeFixture.Logging
+{
+    public static class LoggingExtensionMethods
+    {
+        public static void Log(this ILogger[] loggers, string msg)
+        {
+            foreach (var logger in loggers)
+            {
+                logger.Log(msg);
+            }
+        }
+
+        public static string[] GetLoggedLines(this ILogger[] loggers)
+        {
+            var listLogger = (ListLogger)loggers.Single(l => l is ListLogger);
+            return listLogger.LoggedLines.ToArray();
+        }
+    }
+}

--- a/DockerComposeFixture/Logging/XUnitLogger.cs
+++ b/DockerComposeFixture/Logging/XUnitLogger.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace DockerComposeFixture.Logging
+{
+    public class XUnitLogger : ILogger
+    {
+        private readonly IMessageSink xlogOutput;
+
+        public XUnitLogger(IMessageSink xlogOutput)
+        {
+            this.xlogOutput = xlogOutput;
+        }
+
+        public void OnCompleted()
+        {
+            
+        }
+
+        public void OnError(Exception error)
+        {
+            this.Log(error.Message + "\n" + error.StackTrace);
+            throw error;
+        }
+
+
+        public void OnNext(string value)
+        {
+            this.Log(value);
+        }
+
+        public void Log(string msg)
+        {
+            this.xlogOutput.OnMessage(new DiagnosticMessage(msg));
+        }
+
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# DockerComposeFixture
+# Docker Compose Fixture
 A XUnit fixture that allows you to spin up docker compose files and then run tests against them.
 
-# Example Integration Test
+## Example Integration Test
 
     public class IntegrationTests : IClassFixture<DockerFixture>
     {
@@ -16,3 +16,8 @@ A XUnit fixture that allows you to spin up docker compose files and then run tes
 
         // Tests go here
     }
+
+## Logging
+To enable XUnit logging you will have to add a xunit.runner.json file to your test project. The file should be copied to the output directory and should look like this:
+    
+    { "diagnosticMessages":  true }


### PR DESCRIPTION
improved custom up test handleing and stopped it from always rebuilding on every test execution
added StartupTimeoutSecs option
added default DockerComposeFiles
Handled scenario where docker-compose stops, it no longer waits for StartupTimeoutSecs before erroring
refactored logging code. enabled xlog logging