### PR TITLE
enable to pass environment variables from outside

### DIFF
--- a/DockerComposeFixture/Compose/DockerCompose.cs
+++ b/DockerComposeFixture/Compose/DockerCompose.cs
@@ -12,10 +12,15 @@ namespace DockerComposeFixture.Compose
 {
     public class DockerCompose : IDockerCompose
     {
-        public DockerCompose(ILogger[] logger)
+        private readonly IEnumerable<KeyValuePair<string, object>> environmentVariables;
+
+        public DockerCompose(ILogger[] logger, IEnumerable<KeyValuePair<string, object>> environmentVariables)
         {
+            this.environmentVariables = environmentVariables;
             this.Logger = logger;
         }
+        public DockerCompose(ILogger[] logger) : this(logger, Enumerable.Empty<KeyValuePair<string, object>>()) {}
+        
         private string dockerComposeArgs,dockerComposeUpArgs, dockerComposeDownArgs;
 
         public void Init(string dockerComposeArgs, string dockerComposeUpArgs, string dockerComposeDownArgs)
@@ -33,6 +38,11 @@ namespace DockerComposeFixture.Compose
 
         private void RunProcess(ProcessStartInfo processStartInfo)
         {
+            foreach (var e in environmentVariables)
+            {
+                processStartInfo.EnvironmentVariables[e.Key] = e.Value.ToString();
+            }
+
             var runner = new ProcessRunner(processStartInfo);
             foreach (var logger in this.Logger)
             {

--- a/DockerComposeFixture/DockerFixture.cs
+++ b/DockerComposeFixture/DockerFixture.cs
@@ -76,7 +76,7 @@ namespace DockerComposeFixture
                 : null;
 
             this.Init(options.DockerComposeFiles, options.DockerComposeUpArgs, options.DockerComposeDownArgs,
-                options.StartupTimeoutSecs, options.CustomUpTest, compose, this.GetLoggers(logFile).ToArray());
+                options.StartupTimeoutSecs, options.CustomUpTest, compose, this.GetLoggers(logFile).ToArray(), options.EnvironmentVariables);
         }
 
         private IEnumerable<ILogger> GetLoggers(string file)
@@ -103,14 +103,15 @@ namespace DockerComposeFixture
         /// <param name="customUpTest">Checks whether the docker-compose services have come up correctly based upon the output of docker-compose</param>
         /// <param name="dockerCompose"></param>
         /// <param name="logger"></param>
+        /// <param name="environmentVariables"></param>
         public void Init(string[] dockerComposeFiles, string dockerComposeUpArgs, string dockerComposeDownArgs,
             int startupTimeoutSecs, Func<string[], bool> customUpTest = null,
-            IDockerCompose dockerCompose = null, ILogger[] logger = null)
+            IDockerCompose dockerCompose = null, ILogger[] logger = null, IEnumerable<KeyValuePair<string, object>> environmentVariables = null)
         {
             this.loggers = logger ?? GetLoggers(null).ToArray();
 
             var dockerComposeFilePaths = dockerComposeFiles.Select(this.GetComposeFilePath);
-            this.dockerCompose = dockerCompose ?? new DockerCompose(this.loggers);
+            this.dockerCompose = dockerCompose ?? new DockerCompose(this.loggers, environmentVariables);
             this.customUpTest = customUpTest;
             this.startupTimeoutSecs = startupTimeoutSecs;
 

--- a/DockerComposeFixture/DockerFixtureOptions.cs
+++ b/DockerComposeFixture/DockerFixtureOptions.cs
@@ -34,6 +34,8 @@ namespace DockerComposeFixture
         /// Default is 'docker-compose -f file.yml down --remove-orphans' you can add '--rmi all' if you want to guarantee a fresh build on each test
         /// </summary>
         public string DockerComposeDownArgs { get; set; } = "--remove-orphans";
+        
+        public IEnumerable<KeyValuePair<string, object>> EnvironmentVariables { get; set; }
 
         /// <summary>
         /// How many seconds to wait for the application to start before giving up. (Default is 120.)

--- a/DockerComposeFixture/IDockerFixtureOptions.cs
+++ b/DockerComposeFixture/IDockerFixtureOptions.cs
@@ -11,6 +11,8 @@ namespace DockerComposeFixture
         string DockerComposeUpArgs { get; set; }
         string DockerComposeDownArgs { get; set; }
         int StartupTimeoutSecs { get; set; }
+        
+        IEnumerable<KeyValuePair<string, object>> EnvironmentVariables { get; set; }
 
         void Validate();
 


### PR DESCRIPTION
In my project, I wanted to parameterize `docker-compose` file by environment variables.
So that I can launch multiple instances of docker-compose and each binds to different ports and mounts on different path.

It's working fine in my project. So I will share here.

