### PR TITLE
Fix blocked pipes on windows

### DIFF
--- a/DockerComposeFixture/Compose/ProcessRunner.cs
+++ b/DockerComposeFixture/Compose/ProcessRunner.cs
@@ -36,6 +36,7 @@ namespace DockerComposeFixture.Compose
 
             process.Start();
             process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
             process.WaitForExit();
             process.CancelOutputRead();
 


### PR DESCRIPTION
Process output pipe chokes on windows. This seems to fix it.