### PR TITLE
v1.2.0 - Update test project dependencies and fix pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/DockerComposeFixture.Tests/Compose/ObserverToQueueTests.cs
+++ b/DockerComposeFixture.Tests/Compose/ObserverToQueueTests.cs
@@ -12,18 +12,17 @@ namespace DockerComposeFixture.Tests.Compose
     public class ObserverToQueueTests
     {
         [Fact]
-        public void OnNext_EnqueuesItems_WhenCalled()
+        public async Task OnNext_EnqueuesItems_WhenCalled()
         {
             var observerToQueue = new ObserverToQueue<string>();
             var counter = new ObservableCounter();
             counter.Subscribe(observerToQueue);
             var task = new Task(() => counter.Count());
             Assert.Empty(observerToQueue.Queue);
+            
             task.Start();
-            Thread.Sleep(30);
-            Assert.NotEmpty(observerToQueue.Queue);
-            Assert.True(observerToQueue.Queue.Count < 10);
-            task.Wait();
+            await task;
+            
             Assert.Equal(10, observerToQueue.Queue.Count);
             Assert.Equal("1,2,3,4,5,6,7,8,9,10".Split(","),
                 observerToQueue.Queue.ToArray());

--- a/DockerComposeFixture.Tests/DockerComposeFixture.Tests.csproj
+++ b/DockerComposeFixture.Tests/DockerComposeFixture.Tests.csproj
@@ -1,23 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DockerComposeFixture.Tests/DockerComposeFixture.Tests.csproj
+++ b/DockerComposeFixture.Tests/DockerComposeFixture.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/DockerComposeFixture.Tests/IntegrationTests.cs
+++ b/DockerComposeFixture.Tests/IntegrationTests.cs
@@ -30,7 +30,7 @@ services:
             dockerFixture.InitOnce(() => new DockerFixtureOptions
             {
                 DockerComposeFiles = new[] { this.dockerComposeFile },
-                CustomUpTest = output => output.Any(l => l.Contains("Server is listening"))
+                CustomUpTest = output => output.Any(l => l.Contains("server is listening"))
             });
         }
 

--- a/DockerComposeFixture.Tests/Logging/LoggerTests.cs
+++ b/DockerComposeFixture.Tests/Logging/LoggerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using DockerComposeFixture.Logging;
 using DockerComposeFixture.Tests.Utils;
@@ -36,13 +35,10 @@ namespace DockerComposeFixture.Tests.Logging
             }
             
             var task = new Task(() => counter.Count(delay: 10));
-            
             task.Start();
-            Thread.Sleep(50);
-            var fileLineCount = GetFileLineCount(tmpFile);
-            fileLineCount.Should().BeInRange(1, 9);
             await task;
-            fileLineCount = GetFileLineCount(tmpFile);
+            
+            var fileLineCount = GetFileLineCount(tmpFile);
             fileLineCount.Should().Be(10);
             var lines = File.ReadAllLines(tmpFile);
             lines.Should().BeEquivalentTo("1,2,3,4,5,6,7,8,9,10".Split(","));

--- a/DockerComposeFixture.Tests/Logging/LoggerTests.cs
+++ b/DockerComposeFixture.Tests/Logging/LoggerTests.cs
@@ -24,7 +24,7 @@ namespace DockerComposeFixture.Tests.Logging
             string tmpFile = Path.GetTempFileName();
             int GetFileLineCount(string file)
             {
-                using (var fs = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Write))
+                using (var fs = new FileStream(file, FileMode.OpenOrCreate, FileAccess.Read, FileShare.Write))
                 using (var reader = new StreamReader(fs))
                 {
                     return reader.ReadToEnd()

--- a/DockerComposeFixture.sln
+++ b/DockerComposeFixture.sln
@@ -7,6 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DockerComposeFixture", "Doc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DockerComposeFixture.Tests", "DockerComposeFixture.Tests\DockerComposeFixture.Tests.csproj", "{6FA8890B-5437-4135-B796-7A818CA5DBB6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{2CE05DD1-0760-44A3-AAD3-7A8D133B5244}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/DockerComposeFixture/Compose/DockerCompose.cs
+++ b/DockerComposeFixture/Compose/DockerCompose.cs
@@ -23,7 +23,7 @@ namespace DockerComposeFixture.Compose
 
         public Task Up()
         {
-            var start = new ProcessStartInfo("docker-compose", $"{this.dockerComposeArgs} up {this.dockerComposeUpArgs}");
+            var start = new ProcessStartInfo("docker", $"compose {this.dockerComposeArgs} up {this.dockerComposeUpArgs}");
             return Task.Run(() =>  this.RunProcess(start) );
         }
 
@@ -42,13 +42,13 @@ namespace DockerComposeFixture.Compose
 
         public void Down()
         {
-            var down = new ProcessStartInfo("docker-compose", $"{this.dockerComposeArgs} down {this.dockerComposeDownArgs}");
+            var down = new ProcessStartInfo("docker", $"compose {this.dockerComposeArgs} down {this.dockerComposeDownArgs}");
             this.RunProcess(down);
         }
 
         public IEnumerable<string> Ps()
         {
-            var ps = new ProcessStartInfo("docker-compose", $"{this.dockerComposeArgs} ps");
+            var ps = new ProcessStartInfo("docker", $"compose {this.dockerComposeArgs} ps");
             var runner = new ProcessRunner(ps);
             var observerToQueue = new ObserverToQueue<string>();
 

--- a/DockerComposeFixture/DockerComposeFixture.csproj
+++ b/DockerComposeFixture/DockerComposeFixture.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <IsTestProject>false</IsTestProject>
     <Authors>Joe Shearn</Authors>
     <Product>Docker Compose Fixture</Product>
@@ -13,10 +13,9 @@
     <PackageLicenseUrl>https://github.com/devjoes/DockerComposeFixture/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/devjoes/DockerComposeFixture</RepositoryUrl>
     <PackageTags>docker docker-compose xunit</PackageTags>
-    <PackageReleaseNotes>Added xUnit logging
-Handled scenario where docker-compose stops
-Made it not rebuild on every test run</PackageReleaseNotes>
-    <AssemblyVersion>1.0.11.0</AssemblyVersion>
+    <PackageReleaseNotes>Capture standard error as well as standard out
+Update to use 'docker compose' instead of 'docker-compose' command to run docker compose files</PackageReleaseNotes>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DockerComposeFixture/DockerComposeFixture.nuspec
+++ b/DockerComposeFixture/DockerComposeFixture.nuspec
@@ -3,21 +3,21 @@
   <metadata minClientVersion="2.12">
     <id>dockercomposefixture</id>
     <title>docker-compose Fixture</title>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <authors>Joe Shearn</authors>
     <owners>Joe Shearn</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A XUnit fixture that allows you to spin up docker compose files and then run tests against them.</description>
     <summary>A XUnit fixture that allows you to spin up docker compose files and then run tests against them.</summary>
-    <copyright>Copyright 2018</copyright>
+    <copyright>Copyright 2024</copyright>
     <tags>XUnit Docker Compose</tags>
     <projectUrl>https://github.com/devjoes/DockerComposeFixture</projectUrl>
     <licenseUrl>https://github.com/devjoes/DockerComposeFixture/blob/master/LICENSE</licenseUrl>
     <dependencies>
-      <dependency id="xunit" version="2.3.0" />
+      <dependency id="xunit" version="2.4.1" />
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\netstandard2.0\DockerComposeFixture.dll" target="lib\netstandard2.0\" />
+    <file src="bin\Release\netstandard2.1\DockerComposeFixture.dll" target="lib\netstandard2.1\" />
   </files>
 </package>


### PR DESCRIPTION
Updated the test project to net8 (latest LTS release) and other packages to their latest stable releases.

Fixed the integration test - the output from the docker container used had changed slightly.

Fixed a couple of unit tests which did not run correctly in the GitHub build environment.

Use `docker compose` rather than `docker-compose` to control docker compose as this is now the current command to use.