### PR TITLE
Updates detection of already-running docker compose instances

### DIFF
--- a/DockerComposeFixture.Tests/DockerFixtureTests.cs
+++ b/DockerComposeFixture.Tests/DockerFixtureTests.cs
@@ -22,15 +22,14 @@ namespace DockerComposeFixture.Tests
         {
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
-            compose.Setup(c => c.Ps())
-                .Returns(new[] { "--------", " Up ", " Up " });
+            compose.Setup(c => c.PsWithJsonFormat())
+                .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
             compose.Setup(c => c.Up()).Returns(Task.Delay(ComposeUpRunDurationMs));
 
             new DockerFixture(null)
                 .Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object);
             compose.Verify(c => c.Init(It.IsAny<string>(), "up", "down"), Times.Once);
             compose.Verify(c => c.Down(), Times.Once);
-
         }
 
         [Fact]
@@ -38,9 +37,9 @@ namespace DockerComposeFixture.Tests
         {
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
-            compose.SetupSequence(c => c.Ps())
-                .Returns(new[] { "--------" })
-                .Returns(new[] { "--------", " Up ", " Up " });
+            compose.SetupSequence(c => c.PsWithJsonFormat())
+                .Returns(new[] { "non-json-message" })
+                .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
             compose.Setup(c => c.Up()).Returns(Task.Delay(ComposeUpRunDurationMs));
 
             var tmp = Path.GetTempFileName();
@@ -56,9 +55,9 @@ namespace DockerComposeFixture.Tests
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
             compose.Setup(c => c.Up()).Returns(Task.Delay(ComposeUpRunDurationMs));
-            compose.SetupSequence(c => c.Ps())
-                .Returns(new[] { "--------" })
-                .Returns(new[] { "--------", " Up ", " Up " });
+            compose.SetupSequence(c => c.PsWithJsonFormat())
+                .Returns(new[] { "non-json-message" })
+                .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
 
             var tmp = Path.GetTempFileName();
             var fixture = new DockerFixture(null);
@@ -75,8 +74,8 @@ namespace DockerComposeFixture.Tests
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
             compose.Setup(c => c.Up()).Returns(Task.Delay(5000));
-            compose.Setup(c => c.Ps())
-                .Returns(new[] { "--------", " Up ", " Up " });
+            compose.Setup(c => c.PsWithJsonFormat())
+                .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
             const string successText = "Everything is up";
 
             var logger = new ListLogger();
@@ -100,8 +99,8 @@ namespace DockerComposeFixture.Tests
         {
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
-            compose.Setup(c => c.Ps())
-                .Returns(new[] { "--------", " Up ", " Up " });
+            compose.Setup(c => c.PsWithJsonFormat())
+                .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
             const string successText = "Everything is up";
             var logger = new ListLogger();
             compose.SetupGet(c => c.Logger).Returns(new []{ logger});
@@ -132,27 +131,26 @@ namespace DockerComposeFixture.Tests
             compose.Setup(c => c.Up())
                 .Returns(Task.Delay(ComposeUpRunDurationMs))
                 .Callback(() => stopwatch.Start());
-            compose.Setup(c => c.Ps()).Returns(() =>
+            compose.Setup(c => c.PsWithJsonFormat()).Returns(() =>
             {
                 if (!stopwatch.IsRunning)
                 {
-                    return new[] { "--------" };
+                    return new[] { "non-json-message" };
                 }
-                string firstServiceStatus = stopwatch.ElapsedMilliseconds < 1000 ? " Starting " : " Up ";
-                string secondServiceStatus = stopwatch.ElapsedMilliseconds < 3000 ? " Starting " : " Up ";
+                var firstServiceStatus = stopwatch.ElapsedMilliseconds < 1000 ? "Starting" : "Up 2 seconds";
+                var secondServiceStatus = stopwatch.ElapsedMilliseconds < 3000 ? "Starting" : "Up 4 seconds";
                 return new[]
                 {
                     "blah",
-                    "--------",
-                    $"14f227387e7c\ttestservice1\t\"dotnet TestService...\"\t20 seconds ago\t{firstServiceStatus}\t0.0.0.0:32769->80/tcp\ttestservice_testservice_1",
-                    $"14f227387e7d\ttestservice2\t\"dotnet TestService...\"\t20 seconds ago\t{secondServiceStatus}\t0.0.0.0:32769->89/tcp\ttestservice_testservice_2"
+                    $"{{ \"Status\": \"{firstServiceStatus}\" }}",
+                    $"{{ \"Status\": \"{secondServiceStatus}\" }}"
                 };
             });
 
             new DockerFixture(null).Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object);
 
             compose.Verify(c => c.Up(), Times.Once);
-            compose.Verify(c => c.Ps(), Times.AtLeast(5));
+            compose.Verify(c => c.PsWithJsonFormat(), Times.AtLeast(5));
         }
 
 
@@ -162,10 +160,10 @@ namespace DockerComposeFixture.Tests
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
             bool firstTime = true;
-            compose.Setup(c => c.Ps())
+            compose.Setup(c => c.PsWithJsonFormat())
                 .Returns(() =>
                 {
-                    var data = firstTime ? new[] { "--------" } : new[] { "--------", " Down ", " Down " };
+                    var data = firstTime ? new[] { "non-json-message" } : new[] { "--------", " Down ", " Down " };
                     firstTime = false;
                     return data;
                 });
@@ -184,7 +182,7 @@ namespace DockerComposeFixture.Tests
             
             Assert.Throws<DockerComposeException>(() =>
                 new DockerFixture(null).Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object));
-            compose.Verify(c => c.Ps(), Times.Once);
+            compose.Verify(c => c.PsWithJsonFormat(), Times.Once);
         }
 
         [Fact]
@@ -192,8 +190,8 @@ namespace DockerComposeFixture.Tests
         {
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
-            compose.Setup(c => c.Ps())
-                .Returns(new[] { "--------", " Up ", " Up " });
+            compose.Setup(c => c.PsWithJsonFormat())
+                .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
 
             string fileDoesntExist = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Assert.Throws<ArgumentException>(() =>
@@ -238,9 +236,9 @@ namespace DockerComposeFixture.Tests
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
             compose.Setup(c => c.Up()).Returns(Task.Delay(ComposeUpRunDurationMs));
-            compose.SetupSequence(c => c.Ps())
-                .Returns(new[] { "--------" })
-                .Returns(new[] { "--------", " Up ", " Up " });
+            compose.SetupSequence(c => c.PsWithJsonFormat())
+                .Returns(new[] { "non-json-output" })
+                .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
 
             var fixture = new DockerFixture(null);
             fixture.Init(new[] { Path.GetTempFileName() }, "up", "down", 120, null, compose.Object);

--- a/DockerComposeFixture/Compose/DockerCompose.cs
+++ b/DockerComposeFixture/Compose/DockerCompose.cs
@@ -45,10 +45,25 @@ namespace DockerComposeFixture.Compose
             var down = new ProcessStartInfo("docker", $"compose {this.dockerComposeArgs} down {this.dockerComposeDownArgs}");
             this.RunProcess(down);
         }
-
+        
         public IEnumerable<string> Ps()
         {
             var ps = new ProcessStartInfo("docker", $"compose {this.dockerComposeArgs} ps");
+            var runner = new ProcessRunner(ps);
+            var observerToQueue = new ObserverToQueue<string>();
+
+            foreach (var logger in this.Logger)
+            {
+                runner.Subscribe(logger);
+            }
+            runner.Subscribe(observerToQueue);
+            runner.Execute();
+            return observerToQueue.Queue.ToArray();
+        }
+        
+        public IEnumerable<string> PsWithJsonFormat()
+        {
+            var ps = new ProcessStartInfo("docker", $"compose {this.dockerComposeArgs} ps --format json");
             var runner = new ProcessRunner(ps);
             var observerToQueue = new ObserverToQueue<string>();
 

--- a/DockerComposeFixture/Compose/IDockerCompose.cs
+++ b/DockerComposeFixture/Compose/IDockerCompose.cs
@@ -8,6 +8,7 @@ namespace DockerComposeFixture.Compose
     {
         void Init(string dockerComposeArgs, string dockerComposeUpArgs, string dockerComposeDownArgs);
         void Down();
+        IEnumerable<string> Ps();
         IEnumerable<string> PsWithJsonFormat();
         Task Up();
         int PauseMs { get; }

--- a/DockerComposeFixture/Compose/IDockerCompose.cs
+++ b/DockerComposeFixture/Compose/IDockerCompose.cs
@@ -8,7 +8,7 @@ namespace DockerComposeFixture.Compose
     {
         void Init(string dockerComposeArgs, string dockerComposeUpArgs, string dockerComposeDownArgs);
         void Down();
-        IEnumerable<string> Ps();
+        IEnumerable<string> PsWithJsonFormat();
         Task Up();
         int PauseMs { get; }
         ILogger[] Logger { get; }

--- a/DockerComposeFixture/DockerComposeFixture.csproj
+++ b/DockerComposeFixture/DockerComposeFixture.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <IsTestProject>false</IsTestProject>
     <Authors>Joe Shearn</Authors>
     <Product>Docker Compose Fixture</Product>
@@ -13,9 +13,8 @@
     <PackageLicenseUrl>https://github.com/devjoes/DockerComposeFixture/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/devjoes/DockerComposeFixture</RepositoryUrl>
     <PackageTags>docker docker-compose xunit</PackageTags>
-    <PackageReleaseNotes>Capture standard error as well as standard out
-Update to use 'docker compose' instead of 'docker-compose' command to run docker compose files</PackageReleaseNotes>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <PackageReleaseNotes>Fix issue whereby currently running docker compose was not detected</PackageReleaseNotes>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DockerComposeFixture/DockerComposeFixture.nuspec
+++ b/DockerComposeFixture/DockerComposeFixture.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.12">
     <id>dockercomposefixture</id>
     <title>docker-compose Fixture</title>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <authors>Joe Shearn</authors>
     <owners>Joe Shearn</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/DockerComposeFixture/DockerFixture.cs
+++ b/DockerComposeFixture/DockerFixture.cs
@@ -235,17 +235,15 @@ namespace DockerComposeFixture
             }
             throw new DockerComposeException(this.loggers.GetLoggedLines());
         }
-
+        
         private (bool hasContainers, bool containersAreUp) CheckIfRunning()
         {
-            var lines = this.dockerCompose.Ps().ToList()
-                .Where(l => l != null)
-                .SkipWhile(l => !l.Contains("--------"))
-                .Skip(1)
+            var lines = dockerCompose.PsWithJsonFormat()
+                .Where(l => l != null && l.StartsWith("{"))
                 .ToList();
             return (
                 lines.Any(),
-                lines.Count(l => Regex.IsMatch(l, @"\s+Up\s+")) == lines.Count());
+                lines.Count(l => l.Contains("\"Status\": \"Up")) == lines.Count);
         }
 
         private void Stop()


### PR DESCRIPTION
Current parsing of textural docker compose ps output assumes `"--------"` will delimit output. This is no longer the case. This PR amends us to use the JSON output formatter when invoking docker compose ps.

* Adds `PsWithJson` method to `DockerCompose.cs` to use within the `DockerCompose.cs` `CheckIfRunning` method. This protects us somewhat from future changes to the text output of docker compose ps.

* Updates tests.

I did consider adding a JSON parser library to parse the output (and would be happy to switch to that), but I did not want to bloat any consuming code bases.