### PR TITLE
Adds 'requiredPorts' functionality

### DIFF
--- a/DockerComposeFixture.Tests/DockerFixtureTests.cs
+++ b/DockerComposeFixture.Tests/DockerFixtureTests.cs
@@ -125,7 +125,7 @@ namespace DockerComposeFixture.Tests
         [Fact]
         public void Init_MonitorsServices_WhenTheyStartSlowly()
         {
-            Stopwatch stopwatch = new Stopwatch();
+            var stopwatch = new Stopwatch();
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(100);
             compose.Setup(c => c.Up())
@@ -158,7 +158,7 @@ namespace DockerComposeFixture.Tests
         {
             var compose = new Mock<IDockerCompose>();
             compose.Setup(c => c.PauseMs).Returns(NumberOfMsInOneSec);
-            bool firstTime = true;
+            var firstTime = true;
             compose.Setup(c => c.PsWithJsonFormat())
                 .Returns(() =>
                 {
@@ -191,7 +191,7 @@ namespace DockerComposeFixture.Tests
             compose.Setup(c => c.PsWithJsonFormat())
                 .Returns(new[] { "non-json-message", "{ \"Status\": \"Up 3 seconds\" }", "{ \"Status\": \"Up 15 seconds\" }" });
 
-            string fileDoesntExist = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var fileDoesntExist = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Assert.Throws<ArgumentException>(() =>
                 new DockerFixture(null).Init(new[] { fileDoesntExist }, "up", "down", 120, null, compose.Object));
         }

--- a/DockerComposeFixture.Tests/IntegrationTests.cs
+++ b/DockerComposeFixture.Tests/IntegrationTests.cs
@@ -42,6 +42,8 @@ services:
             Assert.Contains("hello world", response);
         }
 
+        
+        
         public void Dispose()
         {
             File.Delete(this.dockerComposeFile);

--- a/DockerComposeFixture.Tests/RequiredPortsIntegrationTests.cs
+++ b/DockerComposeFixture.Tests/RequiredPortsIntegrationTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using DockerComposeFixture.Exceptions;
+using Xunit;
+
+namespace DockerComposeFixture.Tests;
+
+public class RequiredPortsIntegrationTests : IClassFixture<DockerFixture>, IDisposable
+{
+    private readonly DockerFixture dockerFixture;
+    private readonly string dockerComposeFile;
+
+    private const string DockerCompose = @"
+version: '3.4'
+services:
+    echo_server:
+        image: hashicorp/http-echo
+        ports:
+        - 12871:8080
+        command: -listen=:8080 -text=""hello world""
+        ";
+    
+    public RequiredPortsIntegrationTests(DockerFixture dockerFixture)
+    {
+        this.dockerFixture = dockerFixture;
+        this.dockerComposeFile = Path.GetTempFileName();
+        File.WriteAllText(this.dockerComposeFile, DockerCompose);
+    }
+
+    [Fact]
+    public void Ports_DetermineUtilizedPorts_ReturnsThoseInUse()
+    {
+        // Arrange
+        const ushort portToOccupy = 12871;
+        var ipEndPoint = new IPEndPoint(IPAddress.Loopback, portToOccupy);
+        using Socket listener = new(
+            ipEndPoint.AddressFamily,
+            SocketType.Stream,
+            ProtocolType.Tcp);
+        listener.Bind(ipEndPoint);
+        listener.Listen();
+        
+        // Act
+        var usedPorts = Ports.DetermineUtilizedPorts([12870, 12871, 12872]);
+        
+        // Assert
+        Assert.Single(usedPorts, p => p == 12871);
+    }
+
+    [Fact]
+    public void GivenRequiredPortInUse_ThenExceptionIsThrownWithPortNumber()
+    {
+        const ushort portToOccupy = 12871;
+        var ipEndPoint = new IPEndPoint(IPAddress.Loopback, portToOccupy);
+        using Socket listener = new(
+            ipEndPoint.AddressFamily,
+            SocketType.Stream,
+            ProtocolType.Tcp);
+        listener.Bind(ipEndPoint);
+        listener.Listen();
+        
+        var thrownException = Assert.Throws<PortsUnavailableException>(() =>
+        {
+            dockerFixture.InitOnce(() => new DockerFixtureOptions
+            {
+                DockerComposeFiles = new[] { this.dockerComposeFile },
+                CustomUpTest = output => output.Any(l => l.Contains("server is listening")),
+                RequiredPorts = new ushort[] { portToOccupy }
+            });
+        });
+        
+        Assert.Equivalent(new ushort[] { portToOccupy }, thrownException.Ports);
+    }
+    
+    public void Dispose()
+    {
+        File.Delete(this.dockerComposeFile);
+    }
+}

--- a/DockerComposeFixture.Tests/RequiredPortsIntegrationTests.cs
+++ b/DockerComposeFixture.Tests/RequiredPortsIntegrationTests.cs
@@ -53,6 +53,7 @@ services:
     [Fact]
     public void GivenRequiredPortInUse_ThenExceptionIsThrownWithPortNumber()
     {
+        // Arrange
         const ushort portToOccupy = 12871;
         var ipEndPoint = new IPEndPoint(IPAddress.Loopback, portToOccupy);
         using Socket listener = new(
@@ -62,6 +63,7 @@ services:
         listener.Bind(ipEndPoint);
         listener.Listen();
         
+        // Act & Assert
         var thrownException = Assert.Throws<PortsUnavailableException>(() =>
         {
             dockerFixture.InitOnce(() => new DockerFixtureOptions

--- a/DockerComposeFixture.Tests/Utils/ObservableCounter.cs
+++ b/DockerComposeFixture.Tests/Utils/ObservableCounter.cs
@@ -16,7 +16,7 @@ namespace DockerComposeFixture.Tests.Utils
 
         public void Count(int min = 1, int max = 10, int delay = 10)
         {
-            for (int i = min; i <= max; i++)
+            for (var i = min; i <= max; i++)
             {
                 this.observalbes.ForEach(o => o.OnNext(i.ToString()));
                 Thread.Sleep(delay);

--- a/DockerComposeFixture/DockerComposeFixture.csproj
+++ b/DockerComposeFixture/DockerComposeFixture.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.2.2</Version>
+    <Version>1.3.0</Version>
     <IsTestProject>false</IsTestProject>
     <Authors>Joe Shearn</Authors>
     <Product>Docker Compose Fixture</Product>
@@ -13,8 +13,8 @@
     <PackageLicenseUrl>https://github.com/devjoes/DockerComposeFixture/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/devjoes/DockerComposeFixture</RepositoryUrl>
     <PackageTags>docker docker-compose xunit</PackageTags>
-    <PackageReleaseNotes>Do not throw null reference if fixture is disposed of without being initialized.</PackageReleaseNotes>
-    <AssemblyVersion>1.2.2.0</AssemblyVersion>
+    <PackageReleaseNotes>Add RequiredPorts checking functionality.</PackageReleaseNotes>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DockerComposeFixture/DockerComposeFixture.nuspec
+++ b/DockerComposeFixture/DockerComposeFixture.nuspec
@@ -3,7 +3,7 @@
   <metadata minClientVersion="2.12">
     <id>dockercomposefixture</id>
     <title>docker-compose Fixture</title>
-    <version>1.2.2</version>
+    <version>1.3.0</version>
     <authors>Joe Shearn</authors>
     <owners>Joe Shearn</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/DockerComposeFixture/DockerFixtureOptions.cs
+++ b/DockerComposeFixture/DockerFixtureOptions.cs
@@ -3,12 +3,21 @@
 namespace DockerComposeFixture
 {
     /// <summary>
-    /// Options that control how docker-compose is executed
+    /// Options that control how docker compose is executed
     /// </summary>
     public class DockerFixtureOptions : IDockerFixtureOptions
     {
         /// <summary>
-        /// Checks whether the docker-compose services have come up correctly based upon the output of docker-compose
+        /// An array of ports required to be available on the host in order for the docker compose services
+        /// to start. Provides a fail-fast check along with aiding developers to easier debug issues related
+        /// to running other programs locally with clashing ports.
+        /// If null or empty - no ports are checked.
+        /// If any required ports are reserved by other processes - throws an 'PortsUnavailableException'.
+        /// </summary>
+        public ushort[] RequiredPorts { get; set; }
+
+        /// <summary>
+        /// Checks whether the docker compose services have come up correctly based upon the output of docker compose
         /// </summary>
         public Func<string[], bool> CustomUpTest { get; set; }
 
@@ -19,17 +28,17 @@ namespace DockerComposeFixture
         /// </summary>
         public string[] DockerComposeFiles { get; set; } = new[] { "docker-compose.yml" };
         /// <summary>
-        /// When true this logs docker-compose output to %temp%\docker-compose-*.log
+        /// When true this logs docker compose output to %temp%\docker-compose-*.log
         /// </summary>
         public bool DebugLog { get; set; }
         /// <summary>
-        /// Arguments to append after 'docker-compose -f file.yml up'
-        /// Default is 'docker-compose -f file.yml up' you can append '--build' if you want it to always build
+        /// Arguments to append after 'docker compose -f file.yml up'
+        /// Default is 'docker compose -f file.yml up' you can append '--build' if you want it to always build
         /// </summary>
         public string DockerComposeUpArgs { get; set; } = "";
         /// <summary>
-        /// Arguments to append after 'docker-compose -f file.yml down'
-        /// Default is 'docker-compose -f file.yml down --remove-orphans' you can add '--rmi all' if you want to guarantee a fresh build on each test
+        /// Arguments to append after 'docker compose -f file.yml down'
+        /// Default is 'docker compose -f file.yml down --remove-orphans' you can add '--rmi all' if you want to guarantee a fresh build on each test
         /// </summary>
         public string DockerComposeDownArgs { get; set; } = "--remove-orphans";
 

--- a/DockerComposeFixture/Exceptions/DockerComposeException.cs
+++ b/DockerComposeFixture/Exceptions/DockerComposeException.cs
@@ -2,9 +2,10 @@
 
 namespace DockerComposeFixture.Exceptions
 {
-    public class DockerComposeException:Exception
+    public class DockerComposeException : Exception
     {
-        public DockerComposeException(string[] loggedLines):base($"docker-compose failed - see {nameof(DockerComposeOutput)} property")
+        public DockerComposeException(string[] loggedLines)
+            : base($"docker compose failed - see {nameof(DockerComposeOutput)} property")
         {
             this.DockerComposeOutput = loggedLines;
         }

--- a/DockerComposeFixture/Exceptions/PortsUnavailableException.cs
+++ b/DockerComposeFixture/Exceptions/PortsUnavailableException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace DockerComposeFixture.Exceptions
+{
+    public class PortsUnavailableException : DockerComposeException
+    {
+        public PortsUnavailableException(string[] loggedLines, ushort[] ports) : base(loggedLines)
+        {
+            Ports = ports;
+        }
+
+        public ushort[] Ports { get; set; }
+    }
+}

--- a/DockerComposeFixture/IDockerFixtureOptions.cs
+++ b/DockerComposeFixture/IDockerFixtureOptions.cs
@@ -4,6 +4,7 @@ namespace DockerComposeFixture
 {
     public interface IDockerFixtureOptions
     {
+        UInt16[] RequiredPorts { get; set; }
         Func<string[], bool> CustomUpTest { get; set; }
         string[] DockerComposeFiles { get; set; }
         bool DebugLog { get; set; }

--- a/DockerComposeFixture/Ports.cs
+++ b/DockerComposeFixture/Ports.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Net.NetworkInformation;
+
+namespace DockerComposeFixture
+{
+    public static class Ports
+    {
+        // check if network port is open
+        public static ushort[] DetermineUtilizedPorts(ushort[] ports)
+        {
+            return ports.Where(p => !IsPortAvailable(p)).ToArray();
+        }
+
+        private static bool IsPortAvailable(UInt16 port)
+        {
+            var isAvailable = true;
+            var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+            var tcpConnInfoArray = ipGlobalProperties.GetActiveTcpListeners();
+
+            foreach (var endpoint in tcpConnInfoArray) {
+                if (endpoint.Port == port) {
+                    isAvailable = false;
+                    break;
+                }
+            }
+
+            return isAvailable;
+        }
+    }
+}


### PR DESCRIPTION
I find people often have processes running locally which have port usages similar to those that we wish to spin-up via this library. E.g. a local proxy to a cloud instance of the DB which their app uses. This leads to annoyance and hunting through sometimes cryptic docker compose log lines to discover a simple problem which could have been proactively checked for (fast-fail) prior to docker compose up being invoked.

This PR introduces an optional property 'RequiredPorts' which will be checked for before running docker compose up. If any ports are found to be in use, a custom exception is raised and the clashing ports are surfaced on the 'Ports' property of this exception instance.